### PR TITLE
RWA-1339: spring boot upgrade to 2.6.7 due to CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.6'
+  id 'org.springframework.boot' version '2.6.7'
   id 'com.github.ben-manes.versions' version '0.38.0'
-  id 'org.owasp.dependencycheck' version '6.5.3'
+  id 'org.owasp.dependencycheck' version '7.1.0.1'
   id 'org.sonarqube' version '3.2.0'
-  id 'info.solidsoft.pitest' version '1.5.2'
+  id 'info.solidsoft.pitest' version '1.7.4'
 
 }
 
@@ -121,8 +121,8 @@ jacocoTestCoverageVerification {
 jacocoTestReport {
   executionData(test, integration)
   reports {
-    xml.enabled = true
-    csv.enabled = false
+    xml.required = true
+    csv.required = false
     xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1339


### Change description ###
spring boot upgrade (CVE-2022-22968)
dependencycheck/pitest plugins upgrade
changed deprecated gradle methods to be compatible with next gradle version 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
