### PR TITLE
RWA-1751: upgraded snakeyaml due to CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.0'
+  id 'org.springframework.boot' version '2.7.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.owasp.dependencycheck' version '7.1.1'
   id 'org.sonarqube' version '3.4.0.2513'
@@ -233,6 +233,8 @@ ext.libraries = [
     "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
   ]
 ]
+
+ext['snakeyaml.version'] = '1.31'
 
 dependencies {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1751


### Change description ###
upgraded snakeyaml due to CVE-2022-25857


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
