### PR TITLE
RWA-2052 Changing after callback to afterSuccess callback

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ def branchesToSync = ['demo', 'perftest']
 
 withCamundaOnlyPipeline(type, product, component, s2sServiceName, tenantId) {
 
-  after('test') {
+  afterSuccess('test') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/integration/**/*'
   }


### PR DESCRIPTION
The original after callback has been deprecated

### Change description ###
RWA-2052 Changing after callback to afterSuccess callback in jenkis_CNP file


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
