### PR TITLE
RWA-2250 Cve Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.7'
-  id 'com.github.ben-manes.versions' version '0.39.0'
+  id 'com.github.ben-manes.versions' version '0.45.0'
   id 'org.owasp.dependencycheck' version '8.0.2'
-  id 'org.sonarqube' version '3.4.0.2513'
+  id 'org.sonarqube' version '3.5.0.2730'
   id 'info.solidsoft.pitest' version '1.9.11'
 
 }
@@ -189,15 +189,15 @@ dependencyCheck {
 
 dependencyManagement {
   dependencies {
-    dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.68'
+    dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.70'
 
     // CVE-2018-10237 - Unbounded memory allocation
-    dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
+    dependencySet(group: 'com.google.guava', version: '31.1-jre') {
       entry 'guava'
     }
 
     //CVE-2021-28170
-    dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+    dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'
     //CVE-2021-42550
     dependencySet(group: 'ch.qos.logback', version: '1.2.10') {
       entry 'logback-classic'
@@ -239,7 +239,7 @@ repositories {
 
 def versions = [
   junit           : '5.7.2',
-  junitPlatform   : '1.7.2',
+  junitPlatform   : '1.9.2',
   reformLogging   : '5.1.9',
   springBoot      : '2.7.7',
   springSecurity  : '5.7.5',
@@ -300,7 +300,7 @@ dependencies {
   testImplementation group: 'org.camunda.bpm', name: 'camunda-engine', version: versions.camunda
   testImplementation group: 'org.camunda.bpm.extension', name: 'camunda-bpm-junit5', version: '1.1.0'
 
-  testImplementation group: 'com.h2database', name: 'h2', version: '1.4.200'
+  testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
   integrationTestImplementation "org.junit.vintage:junit-vintage-engine:${versions.junit}"
 
   integrationTestImplementation sourceSets.main.runtimeClasspath


### PR DESCRIPTION
### Change description ###

Bumps com.google.guava:guava from 30.1.1-jre to 31.1-jre.

Bumps com.github.ben-manes.versions from 0.39.0 to 0.45.0.

Bumps h2 from 1.4.200 to 2.1.214.

Bumps org.sonarqube from 3.4.0.2513 to 3.5.0.2730.

Bumps jakarta.el from 4.0.1 to 4.0.2.

Bumps versions.junitPlatform from 1.7.2 to 1.9.2.

Bumps bcpkix-jdk15on from 1.68 to 1.70.

**Before creating a pull request make sure that:**


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
