### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/.github/renovate.json.bak
+++ b/.github/renovate.json.bak
@@ -3,17 +3,21 @@
   "labels": [
     "dependencies"
   ],
+  "helm-requirements": {
+    "fileMatch": [
+      "\\Chart.yaml$"
+    ],
+    "aliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  },
   "extends": [
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/automerge-minor"
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "serenity",
-        "pitest",
-        "pact"
-      ],
+      "matchPackagePatterns": ["serenity", "pitest", "pact"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.